### PR TITLE
Feature/prophet timeseries

### DIFF
--- a/notebook/deepfake_notebook.ipynb
+++ b/notebook/deepfake_notebook.ipynb
@@ -2151,6 +2151,58 @@
     "print(df_ts.head())\n",
     "print(f\"Linhas: {len(df_ts)} | Soma Volume_Deepfakes: {df_ts['Volume_Deepfakes'].sum()}\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Card 12: Previsao de Serie Temporal com Prophet\n",
+    "\n",
+    "Objetivo: adaptar a serie temporal para o padrao do Prophet (`ds`, `y`),\n",
+    "treinar o modelo e gerar previsoes com intervalo de confianca.\n",
+    "\n",
+    "Entregas deste card:\n",
+    "- `data/processed/df_prophet.csv` (colunas `ds` e `y`)\n",
+    "- `data/processed/prophet_forecast.csv`\n",
+    "- `assets/prophet_forecast.png` (previsao com limites superior/inferior)\n",
+    "- `assets/prophet_components.png` (tendencia e sazonalidade semanal)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execucao da pipeline Prophet (Task de Serie Temporal)\n",
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "cwd = Path.cwd()\n",
+    "if (cwd / 'scripts' / 'train_prophet.py').exists():\n",
+    "    project_root = cwd\n",
+    "elif (cwd.parent / 'scripts' / 'train_prophet.py').exists():\n",
+    "    project_root = cwd.parent\n",
+    "else:\n",
+    "    raise FileNotFoundError('Nao foi possivel localizar scripts/train_prophet.py')\n",
+    "\n",
+    "cmd = ['python', str(project_root / 'scripts' / 'train_prophet.py')]\n",
+    "result = subprocess.run(cmd, capture_output=True, text=True)\n",
+    "print(result.stdout)\n",
+    "if result.returncode != 0:\n",
+    "    raise RuntimeError(result.stderr)\n",
+    "\n",
+    "df_prophet = pd.read_csv(project_root / 'data' / 'processed' / 'df_prophet.csv')\n",
+    "df_forecast = pd.read_csv(project_root / 'data' / 'processed' / 'prophet_forecast.csv')\n",
+    "\n",
+    "print('Formato Prophet (ds/y):')\n",
+    "print(df_prophet.head())\n",
+    "print(f'Total de linhas em df_prophet: {len(df_prophet)}')\n",
+    "\n",
+    "print('Forecast (amostra):')\n",
+    "print(df_forecast[['ds', 'yhat', 'yhat_lower', 'yhat_upper']].tail(10))\n"
+   ]
   }
  ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.0.0
+matplotlib>=3.7.0
+prophet>=1.1.5

--- a/scripts/train_prophet.py
+++ b/scripts/train_prophet.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from prophet import Prophet
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train Prophet model using deepfake daily time-series."
+    )
+    parser.add_argument(
+        "--input",
+        default="data/processed/df_timeseries.csv",
+        help="Input daily time-series CSV with Data and Volume_Deepfakes columns.",
+    )
+    parser.add_argument(
+        "--periods",
+        type=int,
+        default=30,
+        help="Number of future days to forecast.",
+    )
+    parser.add_argument(
+        "--out-prophet",
+        default="data/processed/df_prophet.csv",
+        help="Output CSV formatted for Prophet (ds, y).",
+    )
+    parser.add_argument(
+        "--out-forecast",
+        default="data/processed/prophet_forecast.csv",
+        help="Output CSV with Prophet forecast results.",
+    )
+    parser.add_argument(
+        "--out-plot",
+        default="assets/prophet_forecast.png",
+        help="Output forecast plot path.",
+    )
+    parser.add_argument(
+        "--out-components",
+        default="assets/prophet_components.png",
+        help="Output components plot path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    df_ts = pd.read_csv(args.input)
+    required = {"Data", "Volume_Deepfakes"}
+    missing = required - set(df_ts.columns)
+    if missing:
+        raise ValueError(f"Missing required columns: {sorted(missing)}")
+
+    df_prophet = df_ts.rename(columns={"Data": "ds", "Volume_Deepfakes": "y"}).copy()
+    df_prophet["ds"] = pd.to_datetime(df_prophet["ds"])
+
+    model = Prophet()
+    model.fit(df_prophet)
+
+    future = model.make_future_dataframe(periods=args.periods, freq="D")
+    forecast = model.predict(future)
+
+    os.makedirs(os.path.dirname(args.out_prophet), exist_ok=True)
+    os.makedirs(os.path.dirname(args.out_forecast), exist_ok=True)
+    os.makedirs(os.path.dirname(args.out_plot), exist_ok=True)
+    os.makedirs(os.path.dirname(args.out_components), exist_ok=True)
+
+    df_prophet.to_csv(args.out_prophet, index=False)
+    forecast.to_csv(args.out_forecast, index=False)
+
+    fig_forecast = model.plot(forecast)
+    fig_forecast.savefig(args.out_plot, dpi=200, bbox_inches="tight")
+    plt.close(fig_forecast)
+
+    fig_components = model.plot_components(forecast)
+    fig_components.savefig(args.out_components, dpi=200, bbox_inches="tight")
+    plt.close(fig_components)
+
+    print("Prophet pipeline completed.")
+    print(f"Input: {args.input}")
+    print(f"Formatted output (ds,y): {args.out_prophet}")
+    print(f"Forecast output: {args.out_forecast}")
+    print(f"Forecast plot: {args.out_plot}")
+    print(f"Components plot: {args.out_components}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new pipeline for time series analysis of deepfake detection data, adding two major steps: generation of a daily time series from tabular data and forecasting with Facebook Prophet. The changes include new scripts for data transformation and modeling, as well as corresponding notebook cells to orchestrate and document the workflow.

**Time Series Data Engineering:**

* Added a new script `generate_timeseries.py` that converts the tabular classification dataset into a daily time series, either using an existing date column or simulating dates over a two-year period if no date column is present. The script outputs a CSV (`df_timeseries.csv`) with daily counts of "Fake" records, ensuring no missing days in the series.
* Updated the notebook (`deepfake_notebook.ipynb`) to include a new section ("Card 11") that documents and executes the daily aggregation step using the new script, displaying the resulting time series data.

**Time Series Forecasting with Prophet:**

* Added a new script `train_prophet.py` that prepares the time series data for Prophet (renaming columns to `ds` and `y`), trains a Prophet model, generates a 30-day forecast, and saves both the forecast data and plots (forecast and components) to disk.
* Updated the notebook (`deepfake_notebook.ipynb`) to include a new section ("Card 12") that documents and executes the Prophet modeling pipeline, showing sample outputs and generated assets.